### PR TITLE
貸出管理一覧

### DIFF
--- a/src/main/java/jp/co/metateam/library/controller/RentalManageController.java
+++ b/src/main/java/jp/co/metateam/library/controller/RentalManageController.java
@@ -1,14 +1,28 @@
 package jp.co.metateam.library.controller;
-
+import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 
+import jp.co.metateam.library.model.RentalManage;
 import jp.co.metateam.library.service.AccountService;
 import jp.co.metateam.library.service.RentalManageService;
 import jp.co.metateam.library.service.StockService;
 import lombok.extern.log4j.Log4j2;
+import org.springframework.web.bind.annotation.PostMapping;
+import jp.co.metateam.library.model.RentalManageDto;
+import jp.co.metateam.library.service.BookMstService;
+import jp.co.metateam.library.model.BookMst;
+import jp.co.metateam.library.values.RentalStatus;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+import jp.co.metateam.library.model.Account;
+import jp.co.metateam.library.model.Stock;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+
 
 /**
  * 貸出管理関連クラスß
@@ -40,11 +54,28 @@ public class RentalManageController {
     @GetMapping("/rental/index")
     public String index(Model model) {
         // 貸出管理テーブルから全件取得
-
+        List<RentalManage> rentalManageList = this.rentalManageService.findAll();
         // 貸出一覧画面に渡すデータをmodelに追加
-
+        model. addAttribute("rentalManageList",rentalManageList);
         // 貸出一覧画面に遷移
-        return "";
+        return "rental/index";
     }
+
+    @GetMapping("/rental/add")
+    public String add(Model model, @ModelAttribute RentalManageDto rentalManageDto){
+        //貸出登録のプルダウン
+        List<Account> accounts = this.accountService.findAll();
+        List<Stock> stockList = this.stockService.findAll();
+
+        model.addAttribute("accounts", accounts);
+        model.addAttribute("stockList", stockList);
+        model.addAttribute("rentalStatus", RentalStatus.values());
+
+        if(!model.containsAttribute ("rentalManageDto")) {
+            model.addAttribute("rentalManageDto", new RentalManageDto());
+        }
+        return "rental/add";
+    }
+    
 
 }


### PR DESCRIPTION
【概要】
・貸出一覧画面の追加
・貸出登録画面の追加
・新しいブランチ名で再度更新
・プルダウンを作成する際、貸出管理テーブルが不要であったため削除し修正

【テスト証跡】
・貸出一覧画面の表示
・貸出登録画面の表示
・貸出登録の際、プルダウンで各項目を選択できるように表示

大変遅くなってしまい、申し訳ありません。
ご確認よろしくお願いいたします。